### PR TITLE
Fix navbar dropdown menu alignment issue (closes #268)

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -129,6 +129,9 @@ a.dropdown-item {
   #navbarNav div.dropdown-menu {
     margin-top: 0;
     padding-top: .625rem;
+    width: 50%;
+    left: 25%;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Fixes the alignment issue of the dropdown menu for navbar, as described in #268.

The issue was introduced in commit [2cc5915](https://github.com/IACR/conference-template/commit/2cc5915) from PR [#263](https://github.com/IACR/conference-template/pull/263), which removed the div.container wrapper around the navbar. As a result, the navbar now spans the full screen width. However, the dropdown menu remained anchored relative to the left edge of the hovered item, making it appear visually offset to the left on wide screens.

This is fixed by setting the dropdown menu to have a relative 50% width and align to the center of the navbar item.